### PR TITLE
Add RadioMaster Pocket target

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -1692,6 +1692,16 @@
                 "firmware": "Unified_ESP32_2400_TX",
                 "prior_target_name": "RadioMaster_Zorro_2400_TX"
             },
+            "pocket": {
+                "product_name": "RadioMaster Pocket 2.4GHz TX",
+                "lua_name": "RM Pocket",
+                "layout_file": "Radiomaster Zorro.json",
+                "upload_methods": ["uart", "wifi", "etx"],
+                "min_version": "3.0.0",
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_TX",
+                "prior_target_name": "RadioMaster_Zorro_2400_TX"
+            },
             "tx16s": {
                 "product_name": "RadioMaster TX16S Internal 2.4GHz TX",
                 "lua_name": "RM TX16S",


### PR DESCRIPTION
We can leave the version at 3.0.0 as it's just an alias for the Zorro. This means that it can be flashed to all versions that support the Zorro module.