### PR TITLE
Validate targets on PR, push to artifactory on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: Build ExpressLRS
-on: [push, pull_request]
-jobs:
+on:
+  push:
+    branches:
+      - master
 
+jobs:
   package:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,21 @@
+name: Validate
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Validate hardware target files
+      run: |
+        python .github/targets_validator.py


### PR DESCRIPTION
Only validate the targets when creating/pushing to branch other than master.
When merged to master, then we also push to artifactory.