### PR TITLE
Configurable I2C defaults for BetaFPV Super-P

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -121,7 +121,9 @@
                     "pwm_outputs":[13,15,2,0,4,9,10,5,18,23,19,22,3,1],
                     "vbat_offset": 18,
                     "vbat_scale": 1284,
-                    "vbat_atten": 7
+                    "vbat_atten": 7,
+                    "i2c_scl": 19,
+                    "i2c_sda": 22
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.0",
@@ -240,7 +242,9 @@
                     "radio_dcdc": true,
                     "vbat_offset": 18,
                     "vbat_scale": 1284,
-                    "vbat_atten": 7
+                    "vbat_atten": 7,
+                    "i2c_scl": 19,
+                    "i2c_sda": 22
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.0",


### PR DESCRIPTION
This PR adds default values for the I2C pins on the BetaFPV Super-P receivers.
Only merge this after the PR on the main firmware repo is merged.
https://github.com/ExpressLRS/ExpressLRS/pull/2425