### PR TITLE
Support Bandit from 3.3.2

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -1853,7 +1853,7 @@
                 "layout_file": "Radiomaster Bandit.json",
                 "logo_file": "radiomaster.bin",
                 "upload_methods": ["uart", "wifi"],
-                "min_version": "3.4.0",
+                "min_version": "3.3.2",
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX"
             },
@@ -1863,7 +1863,7 @@
                 "layout_file": "Radiomaster Bandit Micro.json",
                 "logo_file": "radiomaster.bin",
                 "upload_methods": ["uart", "wifi"],
-                "min_version": "3.4.0",
+                "min_version": "3.3.2",
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX"
             },
@@ -1876,7 +1876,7 @@
                 },
                 "logo_file": "radiomaster.bin",
                 "upload_methods": ["uart", "wifi"],
-                "min_version": "3.4.0",
+                "min_version": "3.3.2",
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX"
             }


### PR DESCRIPTION
Change the minimum supported version to 3.3.2 as the power fix is in maintenance branch