### PR TITLE
The 900 PA layout is actually for Non-PA receivers!

### DIFF
--- a/RX/Generic 900 True Diversity.json
+++ b/RX/Generic 900 True Diversity.json
@@ -15,17 +15,12 @@
     "radio_dio1_2": 34,
     "radio_nss_2": 13,
 
-    "power_rxen": 10,
-    "power_txen": 14,
-    "power_rxen_2": 9,
-    "power_txen_2": 15,
-
-    "power_min": 3,
-    "power_high": 5,
-    "power_max": 5,
-    "power_default": 5,
+    "power_min": 0,
+    "power_high": 2,
+    "power_max": 2,
+    "power_default": 2,
     "power_control": 0,
-    "power_values": [113, 117, 123],
+    "power_values": [120,124,127],
 
     "led_rgb": 22,
     "led_rgb_isgrb": true,

--- a/targets.json
+++ b/targets.json
@@ -82,7 +82,7 @@
             "dual-core": {
                 "product_name": "BAYCKRC 900MHz Dual Core RX",
                 "lua_name": "BK 900 Dual RX",
-                "layout_file": "Generic 900 True Diversity PA.json",
+                "layout_file": "Generic 900 True Diversity.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.1",
                 "platform": "esp32",
@@ -153,7 +153,7 @@
             "superd": {
                 "product_name": "BETAFPV SuperD 900MHz RX",
                 "lua_name": "BFPV SuperD 900",
-                "layout_file": "Generic 900 True Diversity PA.json",
+                "layout_file": "Generic 900 True Diversity.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.0",
                 "platform": "esp32",
@@ -796,9 +796,9 @@
                 "prior_target_name": "DIY_900_RX_PWMP"
             },
             "true_diversity": {
-                "product_name": "Generic ESP32 True Diversity PA 900MHz RX",
+                "product_name": "Generic ESP32 True Diversity 900MHz RX",
                 "lua_name": "Diversity 900RX",
-                "layout_file": "Generic 900 True Diversity PA.json",
+                "layout_file": "Generic 900 True Diversity.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.0",
                 "platform": "esp32",
@@ -1110,7 +1110,7 @@
             "es900_dual": {
                 "product_name": "HappyModel ES900 Dual RX",
                 "lua_name": "HM ES900 Dual",
-                "layout_file": "Generic 900 True Diversity PA.json",
+                "layout_file": "Generic 900 True Diversity.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.0",
                 "platform": "esp32",


### PR DESCRIPTION
This was just an error in naming the file, so renaming it properly as some 900 receivers are in the works that _do_ have PA.