### PR TITLE
Add secondary RESET pin for 900 TD targets

### DIFF
--- a/RX/Generic 900 True Diversity PA.json
+++ b/RX/Generic 900 True Diversity PA.json
@@ -4,16 +4,17 @@
 
     "radio_miso": 33,
     "radio_mosi": 32,
-    "radio_rst": 26,
     "radio_sck": 25,
 
     "radio_dio0": 36,
     "radio_dio1": 37,
     "radio_nss": 27,
+    "radio_rst": 26,
 
     "radio_dio0_2": 39,
     "radio_dio1_2": 34,
     "radio_nss_2": 13,
+    "radio_rst_2": 21,
 
     "power_rxen": 10,
     "power_txen": 14,

--- a/RX/Generic 900 True Diversity.json
+++ b/RX/Generic 900 True Diversity.json
@@ -4,16 +4,17 @@
 
     "radio_miso": 33,
     "radio_mosi": 32,
-    "radio_rst": 26,
     "radio_sck": 25,
 
     "radio_dio0": 36,
     "radio_dio1": 37,
     "radio_nss": 27,
+    "radio_rst": 26,
 
     "radio_dio0_2": 39,
     "radio_dio1_2": 34,
     "radio_nss_2": 13,
+    "radio_rst_2": 21,
 
     "power_min": 0,
     "power_high": 2,


### PR DESCRIPTION
Add optional secondary reset pin to SX127x targets for consistency with SX128x targets