### PR TITLE
Extra validation of targets

### DIFF
--- a/.github/hardware.py
+++ b/.github/hardware.py
@@ -121,12 +121,32 @@ hardware_fields = {
 }
 
 
+allowable_duplicates = [
+    ['serial_rx', 'serial_tx'],
+    ['screen_sck', 'i2c_scl'],
+    ['screen_sda', 'screen_mosi', 'i2c_sda']
+]
+
+
 def validate(target, layout):
     had_error = False
-    # Ensure that all fields in the layout are valid fields from the hardware list
+    used_pins = {}
     for field in layout:
+        # Ensure that the layout field is a valid field from the hardware list
         if field not in hardware_fields.keys():
             print(f'device "{target}" has an unknown field name {field}')
             had_error = True
-    #
+        # If the type is PIN then it must be unique
+        elif hardware_fields[field] == FieldType.PIN:
+            pin = layout[field]
+            if pin in used_pins.keys():
+                allowed = False
+                for duplicate in allowable_duplicates:
+                    if field in duplicate and used_pins[pin] in duplicate:
+                        allowed = True
+                if not allowed:
+                    print(f'device "{target}" PIN {pin} "{field}" is already assigned to "{used_pins[pin]}"')
+                    had_error = True
+            else:
+                used_pins[pin] = field
     return had_error

--- a/.github/hardware.py
+++ b/.github/hardware.py
@@ -188,6 +188,7 @@ def validate(target, layout, device):
     had_error |= validate_backpack(target, layout)
     had_error |= validate_joystick(target, layout)
     had_error |= validate_pwm_outputs(target, layout)
+    had_error |= validate_vtx_amp_pwm(target, layout, device['platform'])
     return had_error
 
 
@@ -317,4 +318,12 @@ def validate_pin_function(target, layout, field, platform):
         if hardware_fields[field] == FieldType.INPUT and not (function & 1):
             print(f'device "{target}" pin for {field} must be assigned to a pin that supports INPUT')
             return True
+    return False
+
+
+def validate_vtx_amp_pwm(target, layout, platform):
+    if platform == 'esp32' and 'vtx_amp_pwm' in layout:
+        function = get_pin_function(platform, layout['vtx_amp_pwm'])
+        if function is not None and function & 8 != 8:
+            print(f'device "{target}" "vtx_amp_pwm" is preferred to be a DAC pin if possible, but PWM output is supported')
     return False

--- a/.github/hardware.py
+++ b/.github/hardware.py
@@ -1,0 +1,132 @@
+from enum import Enum
+
+
+class FieldType(Enum):
+    PIN = 0
+    INT = 1
+    BOOL = 2
+    FLOAT = 3
+    ARRAY = 4
+    COUNT = 5
+
+
+hardware_fields = {
+    "serial_rx": FieldType.PIN,
+    "serial_tx": FieldType.PIN,
+    "radio_busy": FieldType.PIN,
+    "radio_busy_2": FieldType.PIN,
+    "radio_dio0": FieldType.PIN,
+    "radio_dio0_2": FieldType.PIN,
+    "radio_dio1": FieldType.PIN,
+    "radio_dio1_2": FieldType.PIN,
+    "radio_dio2": FieldType.PIN,
+    "radio_miso": FieldType.PIN,
+    "radio_mosi": FieldType.PIN,
+    "radio_nss": FieldType.PIN,
+    "radio_nss_2": FieldType.PIN,
+    "radio_rst": FieldType.PIN,
+    "radio_rst_2": FieldType.PIN,
+    "radio_sck": FieldType.PIN,
+    "radio_dcdc": FieldType.BOOL,
+    "radio_rfo_hf": FieldType.BOOL,
+    "ant_ctrl": FieldType.PIN,
+    "ant_ctrl_compl": FieldType.PIN,
+    "power_enable": FieldType.PIN,
+    "power_apc1": FieldType.PIN,
+    "power_apc2": FieldType.PIN,
+    "power_rxen": FieldType.PIN,
+    "power_txen": FieldType.PIN,
+    "power_rxen_2": FieldType.PIN,
+    "power_txen_2": FieldType.PIN,
+    "power_lna_gain": FieldType.INT,
+    "power_min": FieldType.INT,
+    "power_high": FieldType.INT,
+    "power_max": FieldType.INT,
+    "power_default": FieldType.INT,
+    "power_pdet": FieldType.PIN,
+    "power_pdet_intercept": FieldType.FLOAT,
+    "power_pdet_slope": FieldType.FLOAT,
+    "power_control": FieldType.INT,
+    "power_values": FieldType.ARRAY,
+    "power_values2": FieldType.ARRAY,
+    "power_values_dual": FieldType.ARRAY,
+    "joystick": FieldType.PIN,
+    "joystick_values": FieldType.ARRAY,
+    "five_way1": FieldType.PIN,
+    "five_way2": FieldType.PIN,
+    "five_way3": FieldType.PIN,
+    "button": FieldType.PIN,
+    "button_led_index": FieldType.INT,
+    "button2": FieldType.PIN,
+    "button2_led_index": FieldType.INT,
+    "led": FieldType.PIN,
+    "led_blue": FieldType.PIN,
+    "led_blue_invert": FieldType.BOOL,
+    "led_green": FieldType.PIN,
+    "led_green_invert": FieldType.BOOL,
+    "led_green_red": FieldType.PIN,
+    "led_red": FieldType.PIN,
+    "led_red_invert": FieldType.BOOL,
+    "led_red_green": FieldType.PIN,
+    "led_rgb": FieldType.PIN,
+    "led_rgb_isgrb": FieldType.BOOL,
+    "ledidx_rgb_status": FieldType.ARRAY,
+    "ledidx_rgb_status_count": FieldType.COUNT,
+    "ledidx_rgb_vtx": FieldType.ARRAY,
+    "ledidx_rgb_vtx_count": FieldType.COUNT,
+    "ledidx_rgb_boot": FieldType.ARRAY,
+    "ledidx_rgb_boot_count": FieldType.COUNT,
+    "screen_cs": FieldType.PIN,
+    "screen_dc": FieldType.PIN,
+    "screen_mosi": FieldType.PIN,
+    "screen_rst": FieldType.PIN,
+    "screen_sck": FieldType.PIN,
+    "screen_sda": FieldType.PIN,
+    "screen_type": FieldType.INT,
+    "screen_reversed": FieldType.BOOL,
+    "screen_bl": FieldType.PIN,
+    "use_backpack": FieldType.BOOL,
+    "debug_backpack_baud": FieldType.INT,
+    "debug_backpack_rx": FieldType.PIN,
+    "debug_backpack_tx": FieldType.PIN,
+    "backpack_boot": FieldType.PIN,
+    "backpack_en": FieldType.PIN,
+    "passthrough_baud": FieldType.INT,
+    "i2c_scl": FieldType.PIN,
+    "i2c_sda": FieldType.PIN,
+    "misc_gsensor_int": FieldType.PIN,
+    "misc_buzzer": FieldType.PIN,
+    "misc_fan_en": FieldType.PIN,
+    "misc_fan_pwm": FieldType.PIN,
+    "misc_fan_tacho": FieldType.PIN,
+    "misc_fan_speeds": FieldType.ARRAY,
+    "misc_fan_speeds_count": FieldType.COUNT,
+    "gsensor_stk8xxx": FieldType.BOOL,
+    "thermal_lm75a": FieldType.BOOL,
+    "pwm_outputs": FieldType.ARRAY,
+    "pwm_outputs_count": FieldType.COUNT,
+    "vbat": FieldType.PIN,
+    "vbat_offset": FieldType.INT,
+    "vbat_scale": FieldType.INT,
+    "vbat_atten": FieldType.INT,
+    "vtx_amp_pwm": FieldType.PIN,
+    "vtx_amp_vpd": FieldType.PIN,
+    "vtx_amp_vref": FieldType.PIN,
+    "vtx_nss": FieldType.PIN,
+    "vtx_miso": FieldType.PIN,
+    "vtx_mosi": FieldType.PIN,
+    "vtx_sck": FieldType.PIN,
+    "vtx_amp_vpd_25mW": FieldType.ARRAY,
+    "vtx_amp_vpd_100mW": FieldType.ARRAY
+}
+
+
+def validate(target, layout):
+    had_error = False
+    # Ensure that all fields in the layout are valid fields from the hardware list
+    for field in layout:
+        if field not in hardware_fields.keys():
+            print(f'device "{target}" has an unknown field name {field}')
+            had_error = True
+    #
+    return had_error

--- a/.github/hardware.py
+++ b/.github/hardware.py
@@ -182,8 +182,18 @@ def validate_power_config(target, layout):
             had_error = True
         if power_max-power_min+1 != len(power_values):
             print(f'device "{target}" power_values must have the correct number of entries to match all values from power_min to power_max')
+            had_error = power_max-power_min+1 > len(power_values)
+        if layout['power_control'] == 3 and 'power_apc2' not in layout:
+            print(f'device "{target}" defines power_control as DACWRITE and power_apc2 is undefined')
             had_error = True
-        if 'power_values2' in layout and len(layout['power_values2']) != len(power_values):
-            print(f'device "{target}" power_values2 must have the same number of entries as power_values')
-            had_error = True
+        if 'power_values2' in layout:
+            if len(layout['power_values2']) != len(power_values):
+                print(f'device "{target}" power_values2 must have the same number of entries as power_values')
+                had_error = True
+            if layout['power_control'] != 3:
+                print(f'device "{target}" power_values2 is defined so power_control must be set to 3 (DACWRITE)')
+                had_error = True
+            if 'power_apc2' not in layout:
+                print(f'device "{target}" power_values2 is defined so the power_apc2 pin must also be defined')
+                had_error = True
     return had_error

--- a/.github/hardware.py
+++ b/.github/hardware.py
@@ -143,6 +143,8 @@ def validate(target, layout):
         else:
             had_error |= validate_pin_uniqueness(target, layout, field)
     had_error |= validate_power_config(target, layout)
+    had_error |= validate_backpack(target, layout)
+    had_error |= validate_joystick(target, layout)
     return had_error
 
 
@@ -196,4 +198,36 @@ def validate_power_config(target, layout):
             if 'power_apc2' not in layout:
                 print(f'device "{target}" power_values2 is defined so the power_apc2 pin must also be defined')
                 had_error = True
+    return had_error
+
+
+def validate_backpack(target, layout):
+    had_error = False
+    if 'passthrough_baud' in layout:
+        if layout['serial_rx'] == layout['serial_tx'] and layout['passthrough_baud'] != 230400:
+            print(f'device "{target}" an external module with a backpack should set the baud rate to 230400')
+            had_error = True
+        if layout['serial_rx'] != layout['serial_tx'] and layout['passthrough_baud'] != 460800:
+            print(f'device "{target}" an internal module with a backpack should set the baud rate to 460800')
+            had_error = True
+    return had_error
+
+
+def validate_joystick(target, layout):
+    had_error = False
+    if 'joystick' in layout or 'joystick_values' in layout:
+        if 'joystick' not in layout:
+            print(f'device "{target}" joystick_values is defined so the joystick pin must also be defined')
+            had_error = True
+        elif 'joystick_values' not in layout:
+            print(f'device "{target}" joystick is defined so the joystick_values must also be defined')
+            had_error = True
+        elif len(layout['joystick_values']) != 6:
+            print(f'device "{target}" joystick_values must have 6 values defined')
+            had_error = True
+        else:
+            for value in layout['joystick_values']:
+                if value < 0 or value > 4095:
+                    print(f'device "{target}" joystick_values must be between 0 and 4095 inclusive')
+                    had_error = True
     return had_error

--- a/.github/hardware.py
+++ b/.github/hardware.py
@@ -1,115 +1,120 @@
 from enum import Enum
+from pin_functions import get_pin_function
 
 
 class FieldType(Enum):
-    PIN = 0
     INT = 1
     BOOL = 2
     FLOAT = 3
     ARRAY = 4
+    PIN = 100   # marker
+    INPUT = 101
+    OUTPUT = 102
+    BIDIR = 103
+    ADC = 104
 
 
 hardware_fields = {
-    "serial_rx": FieldType.PIN,
-    "serial_tx": FieldType.PIN,
-    "radio_busy": FieldType.PIN,
-    "radio_busy_2": FieldType.PIN,
-    "radio_dio0": FieldType.PIN,
-    "radio_dio0_2": FieldType.PIN,
-    "radio_dio1": FieldType.PIN,
-    "radio_dio1_2": FieldType.PIN,
-    "radio_dio2": FieldType.PIN,
-    "radio_miso": FieldType.PIN,
-    "radio_mosi": FieldType.PIN,
-    "radio_nss": FieldType.PIN,
-    "radio_nss_2": FieldType.PIN,
-    "radio_rst": FieldType.PIN,
-    "radio_rst_2": FieldType.PIN,
-    "radio_sck": FieldType.PIN,
+    "serial_rx": FieldType.INPUT,
+    "serial_tx": FieldType.OUTPUT,
+    "radio_busy": FieldType.INPUT,
+    "radio_busy_2": FieldType.INPUT,
+    "radio_dio0": FieldType.INPUT,
+    "radio_dio0_2": FieldType.INPUT,
+    "radio_dio1": FieldType.INPUT,
+    "radio_dio1_2": FieldType.INPUT,
+    "radio_dio2": FieldType.INPUT,
+    "radio_miso": FieldType.INPUT,
+    "radio_mosi": FieldType.OUTPUT,
+    "radio_nss": FieldType.OUTPUT,
+    "radio_nss_2": FieldType.OUTPUT,
+    "radio_rst": FieldType.OUTPUT,
+    "radio_rst_2": FieldType.OUTPUT,
+    "radio_sck": FieldType.OUTPUT,
     "radio_dcdc": FieldType.BOOL,
     "radio_rfo_hf": FieldType.BOOL,
-    "ant_ctrl": FieldType.PIN,
-    "ant_ctrl_compl": FieldType.PIN,
-    "power_enable": FieldType.PIN,
-    "power_apc1": FieldType.PIN,
-    "power_apc2": FieldType.PIN,
-    "power_rxen": FieldType.PIN,
-    "power_txen": FieldType.PIN,
-    "power_rxen_2": FieldType.PIN,
-    "power_txen_2": FieldType.PIN,
+    "ant_ctrl": FieldType.OUTPUT,
+    "ant_ctrl_compl": FieldType.OUTPUT,
+    "power_enable": FieldType.OUTPUT,
+    "power_apc1": FieldType.OUTPUT,
+    "power_apc2": FieldType.OUTPUT,
+    "power_rxen": FieldType.OUTPUT,
+    "power_txen": FieldType.OUTPUT,
+    "power_rxen_2": FieldType.OUTPUT,
+    "power_txen_2": FieldType.OUTPUT,
     "power_lna_gain": FieldType.INT,
     "power_min": FieldType.INT,
     "power_high": FieldType.INT,
     "power_max": FieldType.INT,
     "power_default": FieldType.INT,
-    "power_pdet": FieldType.PIN,
+    "power_pdet": FieldType.ADC,
     "power_pdet_intercept": FieldType.FLOAT,
     "power_pdet_slope": FieldType.FLOAT,
     "power_control": FieldType.INT,
     "power_values": FieldType.ARRAY,
     "power_values2": FieldType.ARRAY,
     "power_values_dual": FieldType.ARRAY,
-    "joystick": FieldType.PIN,
+    "joystick": FieldType.ADC,
     "joystick_values": FieldType.ARRAY,
-    "five_way1": FieldType.PIN,
-    "five_way2": FieldType.PIN,
-    "five_way3": FieldType.PIN,
-    "button": FieldType.PIN,
+    "five_way1": FieldType.INPUT,
+    "five_way2": FieldType.INPUT,
+    "five_way3": FieldType.INPUT,
+    "button": FieldType.INPUT,
     "button_led_index": FieldType.INT,
-    "button2": FieldType.PIN,
+    "button2": FieldType.INPUT,
     "button2_led_index": FieldType.INT,
-    "led": FieldType.PIN,
-    "led_blue": FieldType.PIN,
+    "led": FieldType.OUTPUT,
+    "led_blue": FieldType.OUTPUT,
     "led_blue_invert": FieldType.BOOL,
-    "led_green": FieldType.PIN,
+    "led_green": FieldType.OUTPUT,
     "led_green_invert": FieldType.BOOL,
-    "led_green_red": FieldType.PIN,
-    "led_red": FieldType.PIN,
+    "led_green_red": FieldType.OUTPUT,
+    "led_red": FieldType.OUTPUT,
     "led_red_invert": FieldType.BOOL,
-    "led_red_green": FieldType.PIN,
-    "led_rgb": FieldType.PIN,
+    "led_red_green": FieldType.OUTPUT,
+    "led_rgb": FieldType.OUTPUT,
     "led_rgb_isgrb": FieldType.BOOL,
     "ledidx_rgb_status": FieldType.ARRAY,
     "ledidx_rgb_vtx": FieldType.ARRAY,
     "ledidx_rgb_boot": FieldType.ARRAY,
-    "screen_cs": FieldType.PIN,
-    "screen_dc": FieldType.PIN,
-    "screen_mosi": FieldType.PIN,
-    "screen_rst": FieldType.PIN,
-    "screen_sck": FieldType.PIN,
-    "screen_sda": FieldType.PIN,
+    "screen_cs": FieldType.OUTPUT,
+    "screen_dc": FieldType.OUTPUT,
+    "screen_mosi": FieldType.OUTPUT,
+    "screen_rst": FieldType.OUTPUT,
+    "screen_sck": FieldType.OUTPUT,
+    "screen_sda": FieldType.OUTPUT,
     "screen_type": FieldType.INT,
     "screen_reversed": FieldType.BOOL,
-    "screen_bl": FieldType.PIN,
+    "screen_bl": FieldType.OUTPUT,
     "use_backpack": FieldType.BOOL,
     "debug_backpack_baud": FieldType.INT,
-    "debug_backpack_rx": FieldType.PIN,
-    "debug_backpack_tx": FieldType.PIN,
-    "backpack_boot": FieldType.PIN,
-    "backpack_en": FieldType.PIN,
+    "debug_backpack_rx": FieldType.INPUT,
+    "debug_backpack_tx": FieldType.OUTPUT,
+    "backpack_boot": FieldType.OUTPUT,
+    "backpack_en": FieldType.OUTPUT,
     "passthrough_baud": FieldType.INT,
-    "i2c_scl": FieldType.PIN,
-    "i2c_sda": FieldType.PIN,
-    "misc_gsensor_int": FieldType.PIN,
-    "misc_buzzer": FieldType.PIN,
-    "misc_fan_en": FieldType.PIN,
-    "misc_fan_pwm": FieldType.PIN,
-    "misc_fan_tacho": FieldType.PIN,
+    "i2c_scl": FieldType.OUTPUT,
+    "i2c_sda": FieldType.BIDIR,
+    "misc_gsensor_int": FieldType.INPUT,
+    "misc_buzzer": FieldType.OUTPUT,
+    "misc_fan_en": FieldType.OUTPUT,
+    "misc_fan_pwm": FieldType.OUTPUT,
+    "misc_fan_tacho": FieldType.INPUT,
     "misc_fan_speeds": FieldType.ARRAY,
     "gsensor_stk8xxx": FieldType.BOOL,
     "thermal_lm75a": FieldType.BOOL,
     "pwm_outputs": FieldType.ARRAY,
-    "vbat": FieldType.PIN,
+    "vbat": FieldType.ADC,
     "vbat_offset": FieldType.INT,
     "vbat_scale": FieldType.INT,
     "vbat_atten": FieldType.INT,
-    "vtx_amp_pwm": FieldType.PIN,
-    "vtx_amp_vpd": FieldType.PIN,
-    "vtx_amp_vref": FieldType.PIN,
-    "vtx_nss": FieldType.PIN,
-    "vtx_miso": FieldType.PIN,
-    "vtx_mosi": FieldType.PIN,
-    "vtx_sck": FieldType.PIN,
+    "vtx_amp_pwm": FieldType.OUTPUT,
+    "vtx_amp_vpd": FieldType.ADC,
+    "vtx_amp_vref": FieldType.OUTPUT,
+    "vtx_nss": FieldType.OUTPUT,
+    "vtx_miso": FieldType.INPUT,
+    "vtx_mosi": FieldType.OUTPUT,
+    "vtx_sck": FieldType.OUTPUT,
     "vtx_amp_vpd_25mW": FieldType.ARRAY,
     "vtx_amp_vpd_100mW": FieldType.ARRAY
 }
@@ -157,18 +162,28 @@ allowable_pwm_shared = [
 used_pins = {}
 
 
-def validate(target, layout):
+def ignore_undef_pins(pair):
+    key, value = pair
+    # FIXME, <0 should really be -1, but I used -pin number to mean inverted for the backlight
+    if hardware_fields[key].value > FieldType.PIN.value and value < 0:
+        return False
+    else:
+        return True
+
+
+def validate(target, layout, device):
     global used_pins
     had_error = False
     used_pins = {}
-    for field in layout:
+    for field in dict(filter(ignore_undef_pins, layout.items())):
         # Ensure that the layout field is a valid field from the hardware list
         if field not in hardware_fields.keys():
             print(f'device "{target}" has an unknown field name {field}')
             had_error = True
         else:
             had_error |= validate_pin_uniqueness(target, layout, field)
-        had_error |= validate_grouping(target, layout, field)
+            had_error |= validate_grouping(target, layout, field)
+            had_error |= validate_pin_function(target, layout, field, device['platform'])
     had_error |= validate_power_config(target, layout)
     had_error |= validate_backpack(target, layout)
     had_error |= validate_joystick(target, layout)
@@ -197,7 +212,7 @@ def validate_grouping(target, layout, field):
 
 def validate_pin_uniqueness(target, layout, field):
     had_error = False
-    if hardware_fields[field] == FieldType.PIN:
+    if hardware_fields[field].value > FieldType.PIN.value:
         pin = layout[field]
         if pin in used_pins.keys():
             allowed = False
@@ -284,10 +299,22 @@ def validate_pwm_outputs(target, layout):
     had_error = False
     if 'pwm_outputs' in layout:
         for field in hardware_fields:
-            if hardware_fields[field] == FieldType.PIN and \
+            if hardware_fields[field].value > FieldType.PIN.value and \
                     field in layout and \
                     layout[field] in layout['pwm_outputs'] and \
                     field not in allowable_pwm_shared:
                 print(f'device "{target}" pwm_output pin {layout[field]} is not allowed to be shared with {field}')
                 had_error = True
     return had_error
+
+
+def validate_pin_function(target, layout, field, platform):
+    if hardware_fields[field].value > FieldType.PIN.value:
+        function = get_pin_function(platform, layout[field])
+        if function is None:
+            print(f'device "{target}" has an invalid pin number for {field}, {layout[field]}')
+            return True
+        if hardware_fields[field] == FieldType.INPUT and not (function & 1):
+            print(f'device "{target}" pin for {field} must be assigned to a pin that supports INPUT')
+            return True
+    return False

--- a/.github/pin_functions.py
+++ b/.github/pin_functions.py
@@ -1,0 +1,109 @@
+INPUT = 1
+OUTPUT = 2
+ADC = 4
+DAC = 8
+
+mcu_pin_functions = {
+    "esp8285": {
+        0: INPUT | OUTPUT,
+        1: INPUT | OUTPUT,
+        2: INPUT | OUTPUT,
+        3: INPUT | OUTPUT,
+        4: INPUT | OUTPUT,
+        5: INPUT | OUTPUT,
+        9: INPUT | OUTPUT,
+        10: INPUT | OUTPUT,
+        12: INPUT | OUTPUT,
+        13: INPUT | OUTPUT,
+        14: INPUT | OUTPUT,
+        15: INPUT | OUTPUT,
+        16: INPUT | OUTPUT,
+        17: ADC
+    },
+    "esp32": {
+        0: INPUT | OUTPUT | ADC,
+        1: INPUT | OUTPUT,
+        2: INPUT | OUTPUT | ADC,
+        3: INPUT | OUTPUT,
+        4: INPUT | OUTPUT | ADC,
+        5: INPUT | OUTPUT,
+        9: INPUT | OUTPUT,
+        10: INPUT | OUTPUT,
+        12: INPUT | OUTPUT | ADC,
+        13: INPUT | OUTPUT | ADC,
+        14: INPUT | OUTPUT | ADC,
+        15: INPUT | OUTPUT | ADC,
+        16: INPUT | OUTPUT,
+        17: INPUT | OUTPUT,
+        18: INPUT | OUTPUT,
+        19: INPUT | OUTPUT,
+        21: INPUT | OUTPUT,
+        22: INPUT | OUTPUT,
+        23: INPUT | OUTPUT,
+        25: INPUT | OUTPUT | ADC | DAC,
+        26: INPUT | OUTPUT | ADC | DAC,
+        27: INPUT | OUTPUT | ADC,
+        32: INPUT | OUTPUT | ADC,
+        33: INPUT | OUTPUT | ADC,
+        34: INPUT | ADC,
+        35: INPUT | ADC,
+        36: INPUT | ADC,
+        37: INPUT | ADC,
+        38: INPUT | ADC,
+        39: INPUT | ADC
+    },
+    "esp32-s3": {
+        0: INPUT | OUTPUT,
+        1: INPUT | OUTPUT | ADC,
+        2: INPUT | OUTPUT | ADC,
+        3: INPUT | OUTPUT | ADC,
+        4: INPUT | OUTPUT | ADC,
+        5: INPUT | OUTPUT | ADC,
+        6: INPUT | OUTPUT | ADC,
+        7: INPUT | OUTPUT | ADC,
+        8: INPUT | OUTPUT | ADC,
+        9: INPUT | OUTPUT | ADC,
+        10: INPUT | OUTPUT | ADC,
+        11: INPUT | OUTPUT | ADC,
+        12: INPUT | OUTPUT | ADC,
+        13: INPUT | OUTPUT | ADC,
+        14: INPUT | OUTPUT | ADC,
+        15: INPUT | OUTPUT | ADC,
+        16: INPUT | OUTPUT | ADC,
+        17: INPUT | OUTPUT | ADC,
+        18: INPUT | OUTPUT | ADC,
+        19: INPUT | OUTPUT | ADC,
+        20: INPUT | OUTPUT | ADC,
+        21: INPUT | OUTPUT,
+        # 26: INPUT | OUTPUT, # Used for flash
+        # 27: INPUT | OUTPUT, # Used for flash
+        # 28: INPUT | OUTPUT, # Used for flash
+        # 29: INPUT | OUTPUT, # Used for flash
+        # 30: INPUT | OUTPUT, # Used for flash
+        # 31: INPUT | OUTPUT, # Used for flash
+        # 32: INPUT | OUTPUT, # Used for flash
+        33: INPUT | OUTPUT,
+        34: INPUT | OUTPUT,
+        35: INPUT | OUTPUT,
+        36: INPUT | OUTPUT,
+        37: INPUT | OUTPUT,
+        38: INPUT | OUTPUT,
+        39: INPUT | OUTPUT,
+        40: INPUT | OUTPUT,
+        41: INPUT | OUTPUT,
+        42: INPUT | OUTPUT,
+        43: INPUT | OUTPUT,
+        44: INPUT | OUTPUT,
+        45: INPUT | OUTPUT,
+        46: INPUT | OUTPUT,
+        47: INPUT | OUTPUT,
+        48: INPUT | OUTPUT
+    }
+}
+
+
+def get_pin_function(mcu, pin):
+    if mcu in mcu_pin_functions:
+        if pin in mcu_pin_functions[mcu]:
+            return mcu_pin_functions[mcu][pin]
+    return None

--- a/.github/targets_validator.py
+++ b/.github/targets_validator.py
@@ -59,7 +59,7 @@ def validate_esp(vendor, type, devname, device):
                 layout = json.load(f)
                 if 'overlay' in device:
                     layout.update(device['overlay'])
-                hadError |= hardware.validate(f'{vendor}.{type}.{devname}', layout)
+                hadError |= hardware.validate(f'{vendor}.{type}.{devname}', layout, device)
 
     # could validate overlay
     if 'prior_target_name' not in device:

--- a/.github/targets_validator.py
+++ b/.github/targets_validator.py
@@ -2,6 +2,7 @@ import os, sys
 import json
 import glob
 import argparse
+import hardware
 
 hadError = False
 warnEnabled = False
@@ -48,9 +49,18 @@ def validate_esp(vendor, type, devname, device):
         error(f'device "{vendor}.{type}.{devname}" must have a "layout_file" child element')
     else:
         dir = ('RX/' if type.startswith('rx') else 'TX/')
-        if not os.path.isfile(dir + device['layout_file']):
-            layout_file = device['layout_file']
+        layout_file = device['layout_file']
+        if not os.path.isfile(dir + layout_file):
             error(f'File specified by layout_file "{layout_file}" in target "{vendor}.{type}.{devname}", does not exist')
+        else:
+            # load file, merge overlay, call validate_hardware
+            with open(dir + layout_file, 'r') as f:
+                global hadError
+                layout = json.load(f)
+                if 'overlay' in device:
+                    layout.update(device['overlay'])
+                hadError |= hardware.validate(f'{vendor}.{type}.{devname}', layout)
+
     # could validate overlay
     if 'prior_target_name' not in device:
         warn(f'device "{vendor}.{type}.{devname}" should have a "prior_target_name" child element')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/TX/Generic LR1121 Gemini.json
+++ b/TX/Generic LR1121 Gemini.json
@@ -1,6 +1,6 @@
 {
-    "serial_rx": 23,
-    "serial_tx": 23,
+    "serial_rx": 3,
+    "serial_tx": 1,
 
     "radio_miso": 33,
     "radio_mosi": 32,

--- a/TX/HappyModel ES900.json
+++ b/TX/HappyModel ES900.json
@@ -2,7 +2,6 @@
     "serial_rx": 2,
     "serial_tx": 2,
     "radio_dio0": 26,
-    "radio_dio1": 25,
     "radio_miso": 19,
     "radio_mosi": 23,
     "radio_nss": 5,

--- a/TX/Radiomaster Bandit Micro.json
+++ b/TX/Radiomaster Bandit Micro.json
@@ -11,7 +11,6 @@
   "radio_dcdc": true,
   "radio_rfo_hf": true,
   "power_txen": 33,
-  "power_rxen": 12,
   "power_apc2": 26,
   "power_min": 3,
   "power_high": 6,

--- a/targets.json
+++ b/targets.json
@@ -227,6 +227,7 @@
                 "lua_name": "BFPV SuperG 2G4",
                 "layout_file": "Generic 2400 Gemini.json",
                 "overlay": {
+                    "radio_rst_2": -1,
                     "serial_rx": 21,
                     "serial_tx": 21,
                     "power_min": 1,
@@ -2063,7 +2064,7 @@
                 "lua_name": "RM ER4",
                 "layout_file": "Generic 2400 PWMP5.json",
                 "overlay": {
-                    "power_dcdc": true,
+                    "radio_dcdc": true,
                     "pwm_outputs": [0,1,3,9],
                     "vbat_offset": -10,
                     "vbat_scale": 292


### PR DESCRIPTION
Theres a bunch of extra validation that is added now

- Check hardware field names against the known good set (stops mis-spellings)
- Check for duplicate assignments, i.e. reusing the pin for multiple things
- Validate the power configuration parameters i.e. has the correct number of entries and min/max/high/default are ordered correctly
- Validate that joystick values are correct and that there is 6 of them
- Validate grouped pins are configured correctly i.e. all pins for radio, screen, joystick etc are used when required
- Validate that the PWM pins are not re-used, with notable exceptions for serial and i2c
- Check the assigned pin has the correct support from the MCU e.g. ADC functions assigned to pins that support it
- Warn if the VTX_AMP_PWM pin is not assigned to a DAC pin on ESP32

And finally, fix the issues found by these validations.