### PR TITLE
adjust min_version for full dupleTX 900 esp

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -799,7 +799,7 @@
                 "lua_name": "DupleTX RX",
                 "layout_file": "DIY 900 DupleTX RX.json",
                 "upload_methods": ["uart", "wifi"],
-                "min_version": "3.0.0",
+                "min_version": "3.4.0",
                 "platform": "esp8285",
                 "firmware": "Unified_ESP8285_900_TX"
             }


### PR DESCRIPTION
Build fails on currently released version with the error message:
"Firmware files not found, did you download and unpack them in this directory?"
Reason being there isn't any binaries associated with this target on earlier versions.

Building on Master Branch goes through.

Would be a different case if this is an alias and we're simply adding a new entry into the Targets.json without the need for new hardware definition json file (pin assignments).