### PR TITLE
Adding ESP32C3 targets for testing

### DIFF
--- a/.github/pin_functions.py
+++ b/.github/pin_functions.py
@@ -98,6 +98,30 @@ mcu_pin_functions = {
         46: INPUT | OUTPUT,
         47: INPUT | OUTPUT,
         48: INPUT | OUTPUT
+    },
+    "esp32-c3": {
+        0: INPUT | OUTPUT | ADC,
+        1: INPUT | OUTPUT | ADC,
+        2: INPUT | OUTPUT | ADC,
+        3: INPUT | OUTPUT | ADC,
+        4: INPUT | OUTPUT | ADC,
+        5: INPUT | OUTPUT | ADC,
+        6: INPUT | OUTPUT,
+        7: INPUT | OUTPUT,
+        8: INPUT | OUTPUT,
+        9: INPUT | OUTPUT,
+        10: INPUT | OUTPUT,
+        # 11: INPUT | OUTPUT, # VDD_SPI (backup power line for in-package flash)
+        # 12: INPUT | OUTPUT, # Used for flash
+        # 13: INPUT | OUTPUT, # Used for flash
+        # 14: INPUT | OUTPUT, # Used for flash
+        # 15: INPUT | OUTPUT, # Used for flash
+        # 16: INPUT | OUTPUT, # Used for flash
+        # 17: INPUT | OUTPUT, # Used for flash
+        18: INPUT | OUTPUT,
+        19: INPUT | OUTPUT,
+        20: INPUT | OUTPUT,
+        21: INPUT | OUTPUT,
     }
 }
 

--- a/RX/DIY C3 Super Mini 2400.json
+++ b/RX/DIY C3 Super Mini 2400.json
@@ -14,13 +14,13 @@
     "power_default": 0,
     "power_control": 0,
     "power_values": [13],
-    "pwm_outputs": [0,9,18,19,20,21],
+    "pwm_outputs": [9,10,18,19,20,21],
     "led": 8,
     "led_red_invert": true,
-    "/led_rgb": 0,
+    "/led_rgb": 8,
     "/led_rgb_isgrb": true,
     "/button": 9,
-    "vbat": 10,
+    "vbat": 0,
     "vbat_offset": 12,
     "vbat_scale": 410
 }

--- a/RX/DIY C3 Super Mini 2400.json
+++ b/RX/DIY C3 Super Mini 2400.json
@@ -1,0 +1,23 @@
+{
+    "serial_rx": 20,
+    "serial_tx": 21,
+    "radio_busy": 3,
+    "radio_dio1": 1,
+    "radio_miso": 5,
+    "radio_mosi": 4,
+    "radio_nss": 7,
+    "radio_rst": 2,
+    "radio_sck": 6,
+    "power_min": 0,
+    "power_high": 0,
+    "power_max": 0,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [13],
+    "pwm_outputs": [10],
+    "led": 8,
+    "led_red_invert": true,
+    "led_rgb": 0,
+    "led_rgb_isgrb": true,
+    "button": 9
+}

--- a/RX/DIY C3 Super Mini 2400.json
+++ b/RX/DIY C3 Super Mini 2400.json
@@ -1,6 +1,6 @@
 {
-    "serial_rx": 20,
-    "serial_tx": 21,
+    "/serial_rx": 20,
+    "/serial_tx": 21,
     "radio_busy": 3,
     "radio_dio1": 1,
     "radio_miso": 5,
@@ -14,10 +14,13 @@
     "power_default": 0,
     "power_control": 0,
     "power_values": [13],
-    "pwm_outputs": [10],
+    "pwm_outputs": [0,9,18,19,20,21],
     "led": 8,
     "led_red_invert": true,
-    "led_rgb": 0,
-    "led_rgb_isgrb": true,
-    "button": 9
+    "/led_rgb": 0,
+    "/led_rgb_isgrb": true,
+    "/button": 9,
+    "vbat": 10,
+    "vbat_offset": 12,
+    "vbat_scale": 410
 }

--- a/RX/Generic C3 2400 PWM.json
+++ b/RX/Generic C3 2400 PWM.json
@@ -1,6 +1,4 @@
 {
-    "/serial_rx": 20,
-    "/serial_tx": 21,
     "radio_busy": 3,
     "radio_dio1": 1,
     "radio_miso": 5,
@@ -14,13 +12,9 @@
     "power_default": 0,
     "power_control": 0,
     "power_values": [13],
-    "/pwm_outputs": "Using 18/19 as PWM disables update via USB unless the boot button (9) is pulled low on boot",
     "pwm_outputs": [9,10,18,19,20,21],
-    "led": 8,
-    "led_red_invert": true,
-    "/led_rgb": 8,
-    "/led_rgb_isgrb": true,
-    "/button": 9,
+    "led_rgb": 8,
+    "led_rgb_isgrb": true,
     "vbat": 0,
     "vbat_offset": 12,
     "vbat_scale": 410

--- a/RX/Generic C3 2400.json
+++ b/RX/Generic C3 2400.json
@@ -1,0 +1,20 @@
+{
+    "serial_rx": 20,
+    "serial_tx": 21,
+    "radio_busy": 3,
+    "radio_dio1": 1,
+    "radio_miso": 5,
+    "radio_mosi": 4,
+    "radio_nss": 7,
+    "radio_rst": 2,
+    "radio_sck": 6,
+    "power_min": 0,
+    "power_high": 0,
+    "power_max": 0,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [13],
+    "led_rgb": 8,
+    "led_rgb_isgrb": true,
+    "button": 9
+}

--- a/targets.json
+++ b/targets.json
@@ -877,6 +877,15 @@
             }
         },
         "rx_2400": {
+            "c3": {
+                "product_name": "Generic ESP32C3 2.4Ghz RX",
+                "lua_name": "ELRS 2400RX",
+                "layout_file": "DIY C3 Super Mini 2400.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.4.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_2400_RX"
+            },
             "pp": {
                 "product_name": "Generic STM32 PP 2.4Ghz RX",
                 "upload_methods": ["stlink", "betaflight"],

--- a/targets.json
+++ b/targets.json
@@ -877,10 +877,19 @@
             }
         },
         "rx_2400": {
-            "c3": {
+            "c3-plain": {
                 "product_name": "Generic ESP32C3 2.4Ghz RX",
-                "lua_name": "ELRS 2400RX",
-                "layout_file": "DIY C3 Super Mini 2400.json",
+                "lua_name": "C3 2400RX",
+                "layout_file": "Generic C3 2400.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.4.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_2400_RX"
+            },
+            "c3-pwm": {
+                "product_name": "Generic ESP32C3 PWM 2.4Ghz RX",
+                "lua_name": "C3 PWM 2400RX",
+                "layout_file": "Generic C3 2400 PWM.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.4.0",
                 "platform": "esp32-c3",


### PR DESCRIPTION
Adds 2 targets that can be used for ESP32 C3 testing or as the basis for new manufactured targets...

Also added is DIY json file for the ESP32C3 Super Mini board, but it's does not have a target listed in the main file. It is used mainly for development testing.