### PR TITLE
Adds c3 GemX TD Rx

### DIFF
--- a/RX/Generic C3 LR1121 True Diversity.json
+++ b/RX/Generic C3 LR1121 True Diversity.json
@@ -1,0 +1,33 @@
+{
+    "serial_rx": 20,
+    "serial_tx": 21,
+
+    "radio_miso": 5,
+    "radio_mosi": 4,
+    "radio_sck": 6,
+
+    "radio_busy": 3,
+    "radio_dio1": 1,
+    "radio_nss": 0,
+    "radio_rst": 2,
+
+    "radio_busy_2": 8,
+    "radio_dio1_2": 18,
+    "radio_nss_2": 7,
+    "radio_rst_2": 10,
+
+    "power_min": 0,
+    "power_high": 3,
+    "power_max": 3,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [12,16,19,22],
+    "power_values_dual": [-10,-6,-3,1],
+
+    "led_rgb": 19,
+    "led_rgb_isgrb": true,
+
+    "radio_dcdc": true,
+
+    "button": 9
+}

--- a/targets.json
+++ b/targets.json
@@ -1070,6 +1070,15 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_LR1121_RX"
             },
+            "c3-true_diversity": {
+                "product_name": "Gemini C3 XrossBand PA 2.4/900 RX",
+                "lua_name": "C3 GemX RX",
+                "layout_file": "Generic C3 LR1121 True Diversity.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.4.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_LR1121_RX"
+            },
             "c3-plain": {
                 "product_name": "Generic ESP32C3 2.4Ghz RX",
                 "lua_name": "C3 LR1121 RX",


### PR DESCRIPTION
This PR adds a TD target for the LR1121.  GPIOs have been group together in an effort to make routing easier.

The only additional information required is that GPIO2 (radio_rst) should have a pullup as recommended by Espressif.

https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf

![image](https://github.com/ExpressLRS/targets/assets/14170229/15f56acb-5adb-473d-bb1e-d9f6fed2cfe6)
