### PR TITLE
Add vtx calibration overlay to hm aio targets

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -1342,6 +1342,12 @@
                 "product_name": "HappyModel AIO 2.4GHz RX+VTX",
                 "lua_name": "HM AIO 2400",
                 "layout_file": "Generic 2400 Whoop Rx and VTx.json",
+                "overlay": {
+                    "vtx_amp_vpd_25mW": [948,940,988,1019],
+                    "vtx_amp_vpd_100mW": [1487,1432,1466,1509],
+                    "vtx_amp_pwm_25mW": [3263,3257,3187,3183],
+                    "vtx_amp_pwm_100mW": [3153,3149,3145,3133]
+                },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.4.0",
                 "platform": "esp32",


### PR DESCRIPTION
Updated based on the data provided by the manufacturer.