### PR TITLE
Move RX-as-TX targets to DIY

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -397,6 +397,15 @@
                     "offset": "0x4000",
                     "bootloader": "sx1272_pcb_bootloader.bin"
                 }
+            },
+            "dupletxesp": {
+                "product_name": "Generic ESP8285 Full-duplex 900MHz RX as TX",
+                "lua_name": "DupleTX RX",
+                "layout_file": "DIY 900 DupleTX RX.json",
+                "upload_methods": ["uart", "wifi"],
+                "min_version": "3.4.0",
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_900_TX"
             }
         },
         "rx_900": {
@@ -494,6 +503,16 @@
                 "min_version": "3.4.0",
                 "platform": "esp32-s3",
                 "firmware": "Unified_ESP32S3_2400_TX"
+            },
+            "dupletxesp": {
+                "product_name": "Generic ESP8285 Full-duplex 2.4GHz RX as TX",
+                "lua_name": "DupleTX RX",
+                "layout_file": "DIY 2400 DupleTX ESP.json",
+                "upload_methods": ["uart", "wifi"],
+                "min_version": "3.0.0",
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_TX",
+                "prior_target_name": "DIY_2400_TX_DUPLETX_ESP"
             }
         },
         "rx_2400": {
@@ -793,15 +812,6 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_900_TX",
                 "prior_target_name": "Unified_ESP32_900_TX"
-            },
-            "dupletxesp": {
-                "product_name": "Generic ESP8285 Full-duplex 900MHz RX as TX",
-                "lua_name": "DupleTX RX",
-                "layout_file": "DIY 900 DupleTX RX.json",
-                "upload_methods": ["uart", "wifi"],
-                "min_version": "3.4.0",
-                "platform": "esp8285",
-                "firmware": "Unified_ESP8285_900_TX"
             }
         },
         "rx_900": {
@@ -854,16 +864,6 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_TX",
                 "prior_target_name": "DIY_2400_TX_DUPLETX"
-            },
-            "dupletxesp": {
-                "product_name": "Generic ESP8285 Full-duplex 2.4GHz RX as TX",
-                "lua_name": "DupleTX RX",
-                "layout_file": "DIY 2400 DupleTX ESP.json",
-                "upload_methods": ["uart", "wifi"],
-                "min_version": "3.0.0",
-                "platform": "esp8285",
-                "firmware": "Unified_ESP8285_2400_TX",
-                "prior_target_name": "DIY_2400_TX_DUPLETX_ESP"
             },
             "gemini": {
                 "product_name": "Generic ESP32 2.4Ghz Gemini TX",


### PR DESCRIPTION
After the filtering of "generic/base" targets we need to move the "RX-as-TX" targets to the DIY section.