### PR TITLE
SPRacingH7NEO - Initial target support.

### DIFF
--- a/RX/SPRacing H7NEO 2400 True Diversity RX.json
+++ b/RX/SPRacing H7NEO 2400 True Diversity RX.json
@@ -1,0 +1,68 @@
+{
+    "//": "GPIO Matrix Indexes, 0 = GPIO0, *not* 0 = pin 0",
+
+    "//": "BUTTON",
+    "//": "GPIO0 Strapping - Default: Pull-up - Button pressed pulls-down",
+    "button": 0,
+
+    "//": "SERIAL",
+    "serial_tx": 43,
+    "serial_rx": 44,
+
+    "//": "RADIO (2x 2.4Ghz + 2x PA)",
+
+    "//": "Single inductor fitted to first SX1280",
+    "radio_dcdc": true,
+
+    "//": "Radio SPI uses SUBSPI pins",
+    "radio_miso": 13,
+    "radio_mosi": 11,
+    "radio_sck": 12,
+
+    "//": "NRESET is active-low with 50k pull-up in SX1280",
+    "radio_rst": 9,
+    "radio_rst_2": 46,
+
+    "radio_busy": 7,
+    "radio_busy_2": 5,
+    "radio_dio1": 6,
+    "radio_dio1_2": 4,
+
+    "//": "NSS is active-low, SX1280 MISO is high-impedance when NSS is high.",
+    "//": "NSS 1/2 on SUBSPI pins with CS0/CS1 signals (respectively)",
+    "radio_nss": 10,
+    "radio_nss_2": 8,
+
+    "//": "On the RFX2401C RX active is FALSE when TXEN is HIGH/ON",
+    "power_txen": 14,
+    "power_txen_2": 45,
+
+    "//": "Unused RXEN, pull-ups fitted to both PAs, TXEN HIGH disables RX",
+    "_power_rxen": "N/A",
+    "_power_rxen_2": "N/A",
+
+    "power_lna_gain": 12,
+    "power_min": 0,
+    "power_high": 3,
+    "power_max": 3,
+    "power_default": 3,
+    "power_control": 0,
+    "power_values": [-10,-6,-3,1],
+
+    "//": "PWM",
+    "//": "PWM outputs on 4 pins which double as JTAG pins, on S3 JTAG pins are not strapping pins, no buffers needed!",
+    "//": "GPIO3 is pulled low via 10k resistor (located by IO_1 legend), which selects USB as the JTAG signal source",
+    "//": "See 8.5 JTAG Signal Source Control",
+    "//": "J15:6 - GPIO41/MTDI - JTAG 1/4",
+    "//": "J15:5 - GPIO42/MTMS - JTAG 2/4",
+    "//": "J15:4 - GPIO39/MTCK - JTAG 3/4",
+    "//": "J15:3 - GPIO40/MTDO - JTAG 4/4",
+    "pwm_outputs":[41,42,40,39],
+
+    "//": "LED",
+    "led_rgb": 38,
+    "led_rgb_isgrb": true,
+    "ledidx_rgb_status": [0],
+    "ledidx_rgb_vtx": [1],
+    "ledidx_rgb_boot": [0,1]
+}

--- a/targets.json
+++ b/targets.json
@@ -2428,6 +2428,20 @@
             }
         }
     },
+    "spracing": {
+        "name": "SPRacing",
+        "rx_2400": {
+            "h7neo": {
+                "product_name": "SPRacingH7NEO 2.4GHz FC True Diversity RX (H7/S3)",
+                "lua_name": "SPR_H7NEO_S3",
+                "layout_file": "SPRacing H7NEO 2400 True Diversity RX.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "platform": "esp32-s3",
+                "min_version": "3.3.0",
+                "firmware": "Unified_ESP32S3_2400_RX"
+            }
+        }
+    },
     "atomrc": {
         "name": "atomrc",
         "rx_2400": {


### PR DESCRIPTION
SPRacingH7NEO

* Next-generation STM32 H7 processor with hardware floating point unit for efficient flight calculations and faster ARM-Cortex M7 core running at 520Mhz.
* ExpressLRS True diversity 2.4Ghz radio receiver built in, with 2 power amplifiers (PA) and low noise amplifiers (LNA) for extended range.
* ELRS runs on an ESP32S3 dual core 240Mhz CPU with WIFI.
* ICM42688P gyro with power supply filtering.
* 8Mbps high-speed CAN tranceiver.
* 8 Motor outputs. DSHOT/OneShot/PWM for ESCs and Servos.
* 4MB of Dual Bank OctoSPI External Flash (2x2MB) for firmware.
* 6 Serial Ports - NOT shared with the USB socket, one dedicated to the on-board ELRS receiver.
* 2x Micro USB sockets, one for the H7, one for the ESP32S3.
* 4 corner-mounted RGB LEDs connected to the H7.
* 1 RGB LED for ELRS status.
* 1 LED for FC status.
* Dedicated corner outputs for programmable LEDs - great for orientation, racing and night flying.
* Stackable design with mezzaine IO connectors for future expansion (spi, uart, i2c, gpio, adc, exti)
* HD/DJI video connector (Standard 6-pin DJI pinout).
* 9V 3A regulator.
* 5V 3A regulator.
* 2x 4in1 ESC connectors.
* TVS diode for eliminating voltage spikes.
* TCXO with dedicated power supply for rock-solid 2.4Ghz link frequency stability.
* Battery monitoring for voltage and current.
* Developer friendly debugging port (SWD) and boot mode selection for the H7.
* Built-in JTAG debugger and COM port for the ESP32S3 for ELRS development.
* 3x Side-press buttons, 1 for ELRS and 2 for the H7. For binding/wifi/settings/bootloader control.
* Symmetrical design for a super tidy wiring.
* ELRS PWM/DShot connector for 4 more ELRS controlled PWM/DShot channels.
* JST-SH sockets *and* solder pads for IO. (2x4in1 ESC, UART, CAN, Debug, HD/DJI, PWM)
* Also supports direct connection external of SBus, SumH, SumD, Spektrum1024/2048, CRSF, FPort, SRXL/XBus
receivers.
* H7 Firmware upgradable via USB, ESP32S3 firmware upgradable by Wifi, BF passthrough and USB.
* Standard 30.5mm mounting hole patterns with 4mm holes and grommets for 3mm screws.
* SP Racing logos.

![SPRacingH7NEO-RevA-TOP](https://github.com/ExpressLRS/targets/assets/57075/aac21720-d3cd-4bec-b0b6-76649605448e)
![SPRacingH7NEO-RevA-BOTTOM](https://github.com/ExpressLRS/targets/assets/57075/baab354d-acd0-4a7c-8526-dfe376d88a65)
