### PR TITLE
Swap button pins on the Nano V2s and Super G

### DIFF
--- a/TX/BETAFPV 2400 Nano V2.json
+++ b/TX/BETAFPV 2400 Nano V2.json
@@ -27,8 +27,8 @@
     "led_rgb": 22,
     "led_rgb_isgrb": true,
     "misc_fan_en": 12,
-    "button": 2,
-    "button2": 4,
+    "button": 4,
+    "button2": 2,
 
     "use_backpack": true,
     "debug_backpack_baud": 460800,

--- a/TX/BETAFPV 900 Nano V2.json
+++ b/TX/BETAFPV 900 Nano V2.json
@@ -22,8 +22,8 @@
     "led_rgb": 22,
     "led_rgb_isgrb": true,
     "misc_fan_en": 12,
-    "button": 2,
-    "button2": 4,
+    "button": 4,
+    "button2": 2,
 
     "use_backpack": true,
     "debug_backpack_baud": 460800,

--- a/targets.json
+++ b/targets.json
@@ -266,8 +266,8 @@
                     "power_max": 6,
                     "power_values": [-18,-15,-12,-7,-4,2],
                     "misc_fan_en": 12,
-                    "button": 2,
-                    "button2": 4,
+                    "button": 4,
+                    "button2": 2,
                     "passthrough_baud": 230400
                 },
                 "upload_methods": ["uart", "wifi"],


### PR DESCRIPTION
I noticed the buttons are swapped.
Left Button triggers Button 2 Functions
Right Button triggers Button 1 Functions
(with module facing towards you)

Bandit and Ranger has both
Button 1 on the Left
Button 2 on the Right
(with module facing towards you)