### PR TITLE
Add ThxMrSquid Squid Stick simulator dongle

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -2594,7 +2594,7 @@
         "name": "ThxMrSquid",
         "rx_2400": {
             "squidstick": {
-                "product_name": "Squid Stick dongle",
+                "product_name": "Squid Stick dongle V2",
                 "lua_name": "Squid Stick",
                 "layout_file": "Generic 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],

--- a/targets.json
+++ b/targets.json
@@ -2589,5 +2589,20 @@
                 "prior_target_name": "FD_2400_RX_R24D"
             }
         }
+    },
+    "thxmrsquid": {
+        "name": "ThxMrSquid",
+        "rx_2400": {
+            "squidstick": {
+                "product_name": "Squid Stick dongle",
+                "lua_name": "Squid Stick",
+                "layout_file": "Generic 2400.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.0.0",
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
+            }
+        }
     }
 }


### PR DESCRIPTION
🥳

Video how to fix the bad reception on the V1 dongle, as V1 does not pass our requirements. [YouTube](https://youtu.be/o-24eQoPnho). V1 hardware can also use this target but should perform the mod to vastly increase the range.
