### PR TITLE
Added TCXO to Flywoo receivers

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -644,7 +644,7 @@
         "name": "Flywoo",
         "rx_2400": {
             "el24e": {
-                "product_name": "Flywoo EL24E 2.4GHz RX",
+                "product_name": "Flywoo EL24E TCXO 2.4GHz RX",
                 "lua_name": "Flywoo EL24E",
                 "layout_file": "Generic 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
@@ -654,7 +654,7 @@
                 "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
             },
             "el24p": {
-                "product_name": "Flywoo EL24P 2.4GHz RX",
+                "product_name": "Flywoo EL24P TCXO 2.4GHz RX",
                 "lua_name": "Flywoo EL24P",
                 "layout_file": "Generic 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],


### PR DESCRIPTION
Based on our Documents, the ones we tested and passed are those with TCXO.

![FlywooTcxo](https://github.com/ExpressLRS/targets/assets/83231715/78d7f38e-3070-4269-8ff3-ee588f30423c)

Their product page shows them in white (albeit renders):
https://flywoo.net/products/0.4g-flywoo-tcxo-2.4g-elrs-el24e-el24p

This PR adds "TCXO" on the device target to hopefully set it apart from earlier non-tcxo versions that the dev team wasn't able to check and validate.