### PR TITLE
HelloRadio: Remove the last pin from PWM pin defines (overlap with serial_tx)

### DIFF
--- a/RX/HelloRadio HR7E.json
+++ b/RX/HelloRadio HR7E.json
@@ -25,7 +25,7 @@
     "ledidx_rgb_status": [0],
     "ledidx_rgb_boot": [0],
 
-    "pwm_outputs": [14, 12, 13, 15, 4, 9, 10, 1],
+    "pwm_outputs": [14, 12, 13, 15, 4, 9, 10],
 
     "i2c_sda": 22,
     "i2c_scl": 19,

--- a/RX/HelloRadio HR8E.json
+++ b/RX/HelloRadio HR8E.json
@@ -25,7 +25,7 @@
     "ledidx_rgb_status": [0],
     "ledidx_rgb_boot": [0],
 
-    "pwm_outputs": [14, 12, 13, 15, 4, 9, 10, 5, 1],
+    "pwm_outputs": [14, 12, 13, 15, 4, 9, 10, 5],
 
     "i2c_sda": 22,
     "i2c_scl": 19,


### PR DESCRIPTION
HelloRadio HR8E and HR7E has the last PWM pins shared with `serial_tx` pin (gpio1).

There are three scenario (courtesy of @mha1): 

1. Serial RX/TX on 3/1 and PWM 8 empty
CH8 and the JST connector are now permanently set to the selected serial protocol. Serial Protocol selection is persistent. Outputting PWM data on CH8 is not possible. 

2. Serial RX/TX empty, CH8 on 1
CH8 and JST TX is now permanently outputting PWM data regardless of Serial protocol selections (will be ignored).

3. Serial RX/TX on 3/1, PWM 8 on 1 (this is the current target PR config)
CH8 and JST TX will start outputting PWM data after power-up regardless of Serial protocol selection. Will change to outputting selected Serial protocol after changing the Serial protocol. The new setting is not persistent and will startup in PWM mode again.
Note: this is the failure case the HRS guys complained about in July.

Summary: regardless of any product improvements the current target PR .json is non-functional. 

mha1 and I came to the conclusion that option [1] would most likely avoid user confusion.