### PR TITLE
Add second serial out for RXs that support it

### DIFF
--- a/.github/hardware.py
+++ b/.github/hardware.py
@@ -136,7 +136,7 @@ field_groups = {
         # if one of the first group then all the first and second groups and
         # at-least one of the third group must also be defined
         [["serial_rx", "serial_tx"], [], []],
-        [["serial1_rx", "serial1_tx"], [], []],
+        [["serial1_rx"], ["serial1_tx"], []],
         [["power_min", "power_high", "power_max", "power_default", "power_control", "power_values"], [], []],
         [["debug_backpack_baud", "debug_backpack_rx", "debug_backpack_tx"], [], []],
         [["use_backpack"], ["debug_backpack_baud", "debug_backpack_rx", "debug_backpack_tx"], []],

--- a/targets.json
+++ b/targets.json
@@ -74,9 +74,6 @@
                 "product_name": "BAYCKRC 900MHz Nano RX",
                 "lua_name": "BK 900 Nano RX",
                 "layout_file":  "Generic 900.json",
-                "overlay": {
-                    "serial1_tx": 5
-                },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.1",
                 "platform": "esp8285",

--- a/targets.json
+++ b/targets.json
@@ -74,6 +74,9 @@
                 "product_name": "BAYCKRC 900MHz Nano RX",
                 "lua_name": "BK 900 Nano RX",
                 "layout_file":  "Generic 900.json",
+                "overlay": {
+                    "serial1_tx": 5
+                },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.3.1",
                 "platform": "esp8285",
@@ -104,6 +107,7 @@
                 "lua_name": "BK 2G4 Dual RX",
                 "layout_file": "Generic 2400 True Diversity PA.json",
                 "overlay": {
+                    "serial1_tx": 5,
                     "radio_dcdc": true
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
@@ -1522,6 +1526,7 @@
                 "lua_name": "HGL Gemini2.4RX",
                 "layout_file": "Generic 2400 True Diversity PA.json",
                 "overlay": {
+                    "serial1_tx": 5,
                     "radio_dcdc": true
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],


### PR DESCRIPTION
These receivers just have a single extra pin available so can be used for SmartAudio, Tramp, SBUS etc. i.e. output only.