### PR TITLE
Add BAYCKC C3 LR1121 6PWM receiver

### DIFF
--- a/RX/Generic C3 LR1121.json
+++ b/RX/Generic C3 LR1121.json
@@ -17,7 +17,7 @@
     "power_default": 0,
     "power_control": 0,
     "power_values": [12,16,19,22],
-    "power_values_dual": [-10,-6,-3,1],
+    "power_values_dual": [-12,-9,-6,-2],
 
     "led_rgb": 8,
     "led_rgb_isgrb": true,

--- a/targets.json
+++ b/targets.json
@@ -127,7 +127,7 @@
                 "lua_name": "B 9002G4 nano RX",
                 "layout_file": "Generic C3 LR1121.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_LR1121_RX"
             },

--- a/targets.json
+++ b/targets.json
@@ -123,11 +123,20 @@
                 "firmware": "Unified_ESP32_LR1121_RX"
             },
             "single": {
-                "product_name": "BAYCKRC C3 900/2400 Dual Band RX",
-                "lua_name": "BKRC C3 LR1121",
+                "product_name": "BAYCKRC C3 900/2400 Dual Band Nano RX",
+                "lua_name": "B 9002G4 nano RX",
                 "layout_file": "Generic C3 LR1121.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.4.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_LR1121_RX"
+            },
+            "pwm": {
+                "product_name": "BAYCKRC C3 900/2400 Dual Band 100mw 6PWM RX",
+                "lua_name": "B 9002G4 6PWM RX",
+                "layout_file": "Generic C3 LR1121 PWM.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_LR1121_RX"
             }


### PR DESCRIPTION
Update name of C3 single LR1121 target to match requested naming convention.