### PR TITLE
Fix the default power level for the Generic LR1121 TD target

### DIFF
--- a/RX/Generic LR1121 True Diversity.json
+++ b/RX/Generic LR1121 True Diversity.json
@@ -19,7 +19,7 @@
     "power_min": 0,
     "power_high": 3,
     "power_max": 3,
-    "power_default": 0,
+    "power_default": 3,
     "power_control": 0,
     "power_values": [12,16,19,22],
     "power_values_dual": [-10,-6,-3,1],


### PR DESCRIPTION
Set the default power level to the expected 100mW