### PR TITLE
All C3 targets should be at least 3.5.0

### DIFF
--- a/.github/targets_validator.py
+++ b/.github/targets_validator.py
@@ -64,7 +64,21 @@ def validate_esp(vendor, type, devname, device):
     # could validate overlay
     if 'prior_target_name' not in device:
         warn(f'device "{vendor}.{type}.{devname}" should have a "prior_target_name" child element')
-
+    # Validate the platform matches the firmware file
+    if device['platform'] == 'esp32-c3':
+        if device['min_version'] < '3.5':
+            error(f'device "{vendor}.{type}.{devname}" "min_version" must be at least 3.5.0')
+        if '_ESP32C3_' not in device['firmware']:
+            error(f'device "{vendor}.{type}.{devname}" firmware and platform MUST match')
+    if device['platform'] == 'esp32-s3':
+        if '_ESP32S3_' not in device['firmware']:
+            error(f'device "{vendor}.{type}.{devname}" firmware and platform MUST match')
+    if device['platform'] == 'esp32':
+        if '_ESP32_' not in device['firmware']:
+            error(f'device "{vendor}.{type}.{devname}" firmware and platform MUST match')
+    if device['platform'] == 'esp8285':
+        if '_ESP8285_' not in device['firmware']:
+            error(f'device "{vendor}.{type}.{devname}" firmware and platform MUST match')
 
 def validate_esp32(vendor, type, devname, device):
     for method in device['upload_methods']:
@@ -94,9 +108,9 @@ def validate_devices(vendor, type, devname, device):
         firmware = device['firmware']
         if len(firmwares) != 0 and firmware not in firmwares:
             error(f'device "{vendor}.{type}.{devname}" has an invalid firmware file "{firmware}"')
-        elif (firmware.endswith('_TX') and 'tx_' not in type):
+        elif firmware.endswith('_TX') and 'tx_' not in type:
             error(f'device "{vendor}.{type}.{devname}" has an invalid firmware file "{firmware}", it must be a TX target firmware')
-        elif (firmware.endswith('_RX') and 'rx_' not in type):
+        elif firmware.endswith('_RX') and 'rx_' not in type:
             error(f'device "{vendor}.{type}.{devname}" has an invalid firmware file "{firmware}", it must be an RX target firmware')
 
     if 'platform' not in device:
@@ -137,7 +151,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     warnEnabled = args.warn
 
-    targets = {}
     with open('targets.json') as f:
         targets = json.load(f)
 

--- a/targets.json
+++ b/targets.json
@@ -122,7 +122,7 @@
                     "vbat_atten": 7                  
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_2400_RX"
             }
@@ -976,7 +976,7 @@
                 "lua_name": "C3 2400RX",
                 "layout_file": "Generic C3 2400.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_2400_RX"
             },
@@ -985,7 +985,7 @@
                 "lua_name": "C3 2400 PA RX",
                 "layout_file": "Generic C3 2400 PA.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_2400_RX"
             },
@@ -994,7 +994,7 @@
                 "lua_name": "C3 TD 2400RX",
                 "layout_file": "Generic C3 2400 True Diversity.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_2400_RX"
             },
@@ -1003,7 +1003,7 @@
                 "lua_name": "C3 PWM 2400RX",
                 "layout_file": "Generic C3 2400 PWM.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_2400_RX"
             },
@@ -1187,7 +1187,7 @@
                 "lua_name": "C3 GemX RX",
                 "layout_file": "Generic C3 LR1121 True Diversity.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_LR1121_RX"
             },
@@ -1196,7 +1196,7 @@
                 "lua_name": "C3 LR1121 RX",
                 "layout_file": "Generic C3 LR1121.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_LR1121_RX"
             },
@@ -1205,7 +1205,7 @@
                 "lua_name": "C3 LR1121 PWM RX",
                 "layout_file": "Generic C3 LR1121 PWM.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_LR1121_RX"
             }
@@ -2000,7 +2000,7 @@
                     "vbat_scale": 396
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
-                "min_version": "3.4.0",
+                "min_version": "3.5.0",
                 "platform": "esp32-c3",
                 "firmware": "Unified_ESP32C3_2400_RX"
             }


### PR DESCRIPTION
Add some more validation while we're at it.

- Validate that C3 targets are at least 3.5.0
- Validate the platform and the firmware match