### PR TITLE
So these are pins for `ESP8285_LR1121`

### DIFF
--- a/RX/DBR1 900.json
+++ b/RX/DBR1 900.json
@@ -1,0 +1,25 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+
+    "radio_busy": 4,
+
+    "radio_dio1": 5,
+
+    "radio_miso": 12,
+    "radio_mosi": 13,
+    "radio_sck": 14,
+    "radio_nss": 15,
+    "radio_rst": 2,
+
+    "power_min": 0,
+    "power_max": 3,
+    "power_high": 3,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [12,16,19,22],
+
+    "led": 16,
+
+    "button": 0
+}

--- a/targets.json
+++ b/targets.json
@@ -2904,5 +2904,19 @@
                 "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
             }
         }
+    },
+    "mosquito": {
+        "name": "TheMosquitosGang",
+        "rx_900": {
+            "varnish": {
+                "product_name": "DBR1 Custom Frequencies",
+                "lua_name": "DBR1 Custom Frequencies",
+                "layout_file": "DBR1 900.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.3.0",
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_LR1121_RX"
+            }
+        }
     }
 }


### PR DESCRIPTION
That's it... In order to run it you have to build this thing with `pio` and then flash it with `flash` command. So first you will have to install Python (I'm using 3.11), create venv, install PlatformIO Python lib and install Binarry Configurator ("flash" command, I'm suggesting to install it from sources with -e flag in order to get quick way to change/debug something). After you will install it you will have to make symlinks for hardware repo - `ls -lah "/Users/dsuvorov/Library/Application Support/ExpressLRS Configurator/firmwares/binary-targets"`. That's where PlatformIO installed itself on my mac... Something like:
```
ln -s /Users/dsuvorov/dev/rep/open/targets/targets.json "/Users/dsuvorov/Library/Application Support/ExpressLRS Configurator/firmwares/binary-targets/hardware/targets.json"
ln -s /Users/dsuvorov/dev/rep/open/targets/TX "/Users/dsuvorov/Library/Application Support/ExpressLRS Configurator/firmwares/binary-targets/hardware/TX"
ln -s /Users/dsuvorov/dev/rep/open/targets/RX "/Users/dsuvorov/Library/Application Support/ExpressLRS Configurator/firmwares/binary-targets/hardware/RX"
ln -s /Users/dsuvorov/dev/rep/open/targets/logo "/Users/dsuvorov/Library/Application Support/ExpressLRS Configurator/firmwares/binary-targets/hardware/logo"
```

After everything is installed you can take this function, add to your `bash_profile` or something and try it:
```
build_and_flash() {
  pio run -e Unified_ESP8285_LR1121_RX_via_BetaflightPassthrough ;
  cp -R /Users/dsuvorov/dev/rep/mosquitos/ExpressLRS/src/.pio/build/Unified_ESP8285_LR1121_RX_via_BetaflightPassthrough ~/dev/drones/shit/FCC/Unified_ESP8285_LR1121_RX ;
  echo "Copied to the shit ;"
  ls -laht ~/dev/drones/shit/FCC/ ;
  flash --dir /Users/dsuvorov/dev/rep/mosquitos/ExpressLRS/src --fdir ~/dev/drones/shit --target mosquito.rx_900.varnish --domain ua_960 --auto-wifi 60 --lock-on-first-connection --flash bf --port /dev/cu.usbmodem0x80000001 --phrase mosquito
}
```