### PR TITLE
add c3 diversity pa json

### DIFF
--- a/RX/Generic C3 2400 Diversity PA.json
+++ b/RX/Generic C3 2400 Diversity PA.json
@@ -1,0 +1,23 @@
+{
+    "serial_rx": 20,
+    "serial_tx": 21,
+    "radio_busy": 3,
+    "radio_dio1": 1,
+    "radio_miso": 5,
+    "radio_mosi": 4,
+    "radio_nss": 7,
+    "radio_rst": 2,
+    "radio_sck": 6,
+    "ant_ctrl": 18,
+    "power_txen": 19,
+    "power_lna_gain": 12,
+    "power_min": 0,
+    "power_high": 3,
+    "power_max": 3,
+    "power_default": 3,
+    "power_control": 0,
+    "power_values": [-10,-6,-3,1],
+    "led_rgb": 8,
+    "led_rgb_isgrb": true,
+    "button": 9
+}


### PR DESCRIPTION
Providing a Diversity PA setup for the ESP32-C3, allowing it to perform automatic antenna switching.