### PR TITLE
Added new target Orbit_2400_Nano_RX

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -3167,5 +3167,23 @@
                 "prior_target_name": "DIY_2400_RX_ESP8285_SX1280"
             }
         }
+    },
+    "orbit": {
+        "name": "ORBIT",
+        "rx_2400": {
+            "nano": {
+                "product_name": "ORBIT 2.4Ghz Nano RX",
+                "lua_name": "ORBIT 2400 RX",
+                "layout_file": "Generic 2400 PA RGB.json",
+                "overlay": {
+                    "radio_dcdc": true
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.0.0",
+                "platform": "esp8285",
+                "firmware": "Unified_ESP8285_2400_RX",
+                "prior_target_name": "Orbit_2400_Nano_RX"
+            }
+        }
     }
 }


### PR DESCRIPTION
### Add New Target: `ORBIT 2.4GHz Nano RX`

This PR adds support for a new custom receiver hardware named **ORBIT 2.4GHz Nano RX** to ExpressLRS. The necessary configuration has been added to `target.json`.

#### Hardware Specifications:
- **MCU**: ESP8285  
- **RF Chip**: SX1280  
- **PA/LNA**: RFx2401  
- **Dimensions**: Nano (12mm x 19mm)

#### Testing:
- Firmware compiled and flashed successfully via ExpressLRS Configurator  
- Binding verified  
- Packet reception confirmed  
- Telemetry functioning properly  
- Failsafe response tested and working

Let me know if anything else is needed for review. Thanks!
