### PR TITLE
Add RadioMaster Nexus-XR target

### DIFF
--- a/RX/Generic 2400 True Diversity.json
+++ b/RX/Generic 2400 True Diversity.json
@@ -1,0 +1,32 @@
+{
+    "serial_rx": 3,
+    "serial_tx": 1,
+
+    "radio_miso": 33,
+    "radio_mosi": 32,
+    "radio_sck": 25,
+
+    "radio_busy": 36,
+    "radio_dio1": 37,
+    "radio_nss": 27,
+    "radio_rst": 26,
+
+    "radio_busy_2": 39,
+    "radio_dio1_2": 34,
+    "radio_nss_2": 13,
+    "radio_rst_2": 21,
+
+    "power_min": 0,
+    "power_high": 0,
+    "power_max": 0,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [13],
+
+    "led_rgb": 22,
+    "led_rgb_isgrb": true,
+    "ledidx_rgb_status": [0],
+    "ledidx_rgb_boot": [0],
+
+    "button": 0
+}

--- a/targets.json
+++ b/targets.json
@@ -2999,20 +2999,24 @@
             "rp4m": {
                 "product_name": "RadioMaster RP4TD-M True Diversity 2.4GHz RX",
                 "lua_name": "RM RP4TD-M 2400",
-                "layout_file": "Generic 2400 True Diversity PA.json",
-                "overlay": {
-		    "power_high": 0,
-		    "power_max": 0,
-		    "power_default": 0,
-                    "power_values": [13]
-                },
+                "layout_file": "Generic 2400 True Diversity.json",
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.0.0",
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_2400_RX",
                 "prior_target_name": "Unified_ESP32_2400_RX"
             },
-	    "xr2": {
+            "nexus-xr": {
+                "product_name": "Radiomaster Nexus-XR True Diversity 2.4GHz RX",
+                "lua_name": "RM NEXUSXR",
+                "layout_file": "Generic 2400 True Diversity.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_2400_RX",
+                "prior_target_name": "Unified_ESP32_2400_RX"
+            },
+            "xr2": {
                 "product_name": "RadioMaster XR2 2.4GHz RX",
                 "lua_name": "RM XR2",
                 "layout_file": "Generic C3 LR1121.json",


### PR DESCRIPTION
Create "Generic 2400 True Diversity.json" file.
Use it for the Nexus-XR and the RP4TD-M. It should have been done this way previously as the PA target file also defines "power_lna_gain", but these targets don't have a PA and hence no LNA.