### PR TITLE
Add Spedix/THobby receiver targets

### DIFF
--- a/targets.json
+++ b/targets.json
@@ -3262,6 +3262,58 @@
             }
         }
     },
+    "spedix": {
+        "name": "Spedix",
+        "rx_2400": {
+            "spx24": {
+                "product_name": "Spedix 2.4GHz RX",
+                "lua_name": "SPX 2G4 RX",
+                "layout_file": "Generic C3 2400.json",
+                "overlay": {
+                    "led_rgb": -1,
+                    "led": 19
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_2400_RX"
+            }
+        },
+        "rx_900": {
+            "spx900": {
+                "product_name": "Spedix 900MHz RX",
+                "lua_name": "SPX 900 RX",
+                "layout_file": "Generic C3 LR1121.json",
+                "overlay": {
+                    "radio_nss": 0,
+                    "power_values_dual": null,
+                    "led": 19,
+                    "led_rgb": null,
+                    "led_rgb_isgrb": null
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_LR1121_RX"
+            }
+        },
+        "rx_dual": {
+            "spxdb": {
+                "product_name": "Spedix Dual Band RX",
+                "lua_name": "SPX Dual Band",
+                "layout_file": "Generic C3 LR1121.json",
+                "overlay": {
+                    "power_values_dual": [-9, -5, -1, 2],
+                    "radio_nss": 0,
+                    "led_rgb": 19
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_LR1121_RX"
+            }
+        }
+    },
     "speedybee": {
         "name": "SpeedyBee",
         "rx_900": {
@@ -3333,6 +3385,58 @@
                 "platform": "esp32",
                 "min_version": "3.3.0",
                 "firmware": "Unified_ESP32_2400_RX"
+            }
+        }
+    },
+    "thobby": {
+        "name": "THOBBY",
+        "rx_2400": {
+            "thobby24": {
+                "product_name": "THOBBY 2.4GHz RX",
+                "lua_name": "TH 2G4 RX",
+                "layout_file": "Generic C3 2400.json",
+                "overlay": {
+                    "led_rgb": -1,
+                    "led": 19
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_2400_RX"
+            }
+        },
+        "rx_900": {
+            "thobb900": {
+                "product_name": "THOBBY 900MHz RX",
+                "lua_name": "TH 900 RX",
+                "layout_file": "Generic C3 LR1121.json",
+                "overlay": {
+                    "radio_nss": 0,
+                    "power_values_dual": null,
+                    "led": 19,
+                    "led_rgb": null,
+                    "led_rgb_isgrb": null
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_LR1121_RX"
+            }
+        },
+        "rx_dual": {
+            "thobbdb": {
+                "product_name": "THOBBY Dual Band RX",
+                "lua_name": "TH Dual Band",
+                "layout_file": "Generic C3 LR1121.json",
+                "overlay": {
+                    "power_values_dual": [-9, -5, -1, 2],
+                    "radio_nss": 0,
+                    "led_rgb": 19
+                },
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "3.5.0",
+                "platform": "esp32-c3",
+                "firmware": "Unified_ESP32C3_LR1121_RX"
             }
         }
     },

--- a/targets.json
+++ b/targets.json
@@ -3288,8 +3288,7 @@
                     "radio_nss": 0,
                     "power_values_dual": null,
                     "led": 19,
-                    "led_rgb": null,
-                    "led_rgb_isgrb": null
+                    "led_rgb": -1
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.5.0",
@@ -3406,7 +3405,7 @@
             }
         },
         "rx_900": {
-            "thobb900": {
+            "thobby900": {
                 "product_name": "THOBBY 900MHz RX",
                 "lua_name": "TH 900 RX",
                 "layout_file": "Generic C3 LR1121.json",
@@ -3414,8 +3413,7 @@
                     "radio_nss": 0,
                     "power_values_dual": null,
                     "led": 19,
-                    "led_rgb": null,
-                    "led_rgb_isgrb": null
+                    "led_rgb": -1
                 },
                 "upload_methods": ["uart", "wifi", "betaflight"],
                 "min_version": "3.5.0",
@@ -3424,7 +3422,7 @@
             }
         },
         "rx_dual": {
-            "thobbdb": {
+            "thobbydb": {
                 "product_name": "THOBBY Dual Band RX",
                 "lua_name": "TH Dual Band",
                 "layout_file": "Generic C3 LR1121.json",


### PR DESCRIPTION
Three RX targets
- 2.4GHz ( two variants, tower and external antenna)
- 900MHz (LR1121)
- Dual Band

These are also duplicated to THobby.