### PR TITLE
Add nomad rx target

### DIFF
--- a/RX/Radiomaster Nomad.json
+++ b/RX/Radiomaster Nomad.json
@@ -1,0 +1,42 @@
+{
+  "serial_rx": 3,
+  "serial_tx": 1,
+
+  "radio_miso": 33,
+  "radio_mosi": 32,
+  "radio_sck": 25,
+
+  "radio_busy": 36,
+  "radio_dio1": 37,
+  "radio_nss": 27,
+  "radio_rst": 15,
+
+  "radio_busy_2": 39,
+  "radio_dio1_2": 34,
+  "radio_nss_2": 13,
+  "radio_rst_2": 21,
+
+  "radio_dcdc": true,
+  "radio_rfo_hf": true,
+
+  "power_apc2": 26,
+  "power_min": 0,
+  "power_high": 6,
+  "power_max": 6,
+  "power_default": 3,
+  "power_control": 3,
+  "power_values": [120,120,120,120,120,120,95],
+  "power_values2": [-17,-16,-14,-11,-7,-3,5],
+  "power_values_dual": [-18,-14,-8,-6,-2,3,5],
+  "power_lna_gain": 12,
+
+  "led_rgb": 22,
+  "led_rgb_isgrb": true,
+  "ledidx_rgb_status": [0,1],
+  "ledidx_rgb_boot": [0,1],
+
+  "button": 14,
+  "button2": 12,
+
+  "misc_fan_en": 2
+}

--- a/targets.json
+++ b/targets.json
@@ -3671,6 +3671,15 @@
                 "platform": "esp32",
                 "firmware": "Unified_ESP32_LR1121_RX"
             },
+            "nomad-rx": {
+                "product_name": "RadioMaster Nomad 2.4/900 RX",
+                "lua_name": "RM Nomad RX",
+                "layout_file": "Radiomaster Nomad.json",
+                "upload_methods": ["uart", "wifi", "betaflight"],
+                "min_version": "4.0.0",
+                "platform": "esp32",
+                "firmware": "Unified_ESP32_LR1121_RX"
+            },
             "xr1": {
                 "product_name": "RadioMaster XR1 Dual Band RX",
                 "lua_name": "RM XR1",


### PR DESCRIPTION
Adds configurations for RadioMaster Nomad external module as RX.