### PR TITLE
add lightfin nano 2.4Ghz 6pwm

### DIFF
--- a/RX/LightFin Nano.json
+++ b/RX/LightFin Nano.json
@@ -1,0 +1,22 @@
+{
+    "i2c_scl": 8,
+    "i2c_sda": 9,
+    "radio_dio1": 2,
+    "radio_miso": 10,
+    "radio_mosi": 7,
+    "radio_nss": 5,
+    "radio_sck": 6,
+    "power_min": 0,
+    "power_high": 0,
+    "power_max": 0,
+    "power_default": 0,
+    "power_control": 0,
+    "power_values": [13],
+    "power_lna_gain": 0,
+    "pwm_outputs": [0,18,20,19,21,4],
+    "led": 3,
+    "vbat": 1,
+    "vbat_scale": 910,
+    "vbat_offset": 0,
+    "vbat_atten": 7
+}


### PR DESCRIPTION
Hi LightFin nano is a micro ELRS receiver with 6 PWM channels and IMU:

6-channel output: Supports six micro-servo connections
Brushed motor drive: Supports four brushed motor outputs shared with the servo connections, up to 5A per channel
6-axis motion sensing: Equipped with a domestically produced 6-axis IMU
Ultra-light design: Approximately 2.5g with all connectors, or 1g without connectors

hope to be merged in, and how to contact to send samples to developers?
Thank you, feel free to comment.

sch:
[SCH_LightFin_Nano_2026-08-12.pdf](https://github.com/user-attachments/files/30970714/SCH_LightFin_Nano_2026-08-12.pdf)


<img width="2160" height="1185" alt="3D_PCB1_2_2026-08-12 (1)" src="https://github.com/user-attachments/assets/f557c7d4-50f8-4a78-ae10-031749080319" />
<img width="2160" height="1185" alt="3D_PCB1_2_2026-08-12" src="https://github.com/user-attachments/assets/6e99b3c6-cad2-404e-b9f1-bb13d14e640f" />
